### PR TITLE
fix jsonapi content type validation function

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -64,9 +64,9 @@ def error(msg, status=400, **kwargs):
 
 def validate_json_api_content_type(request):
     """Validate whether the content type of the request is application/vnd.api+json."""
-    if "/^application/vnd.api+json" not in request.args.get('CONTENT_TYPE'):
-        return error("Content-Type must be application/vnd.api+json instead of" +
-                     request.args.get('CONTENT_TYPE'))
+    if "application/vnd.api+json" not in request.content_type:
+        return error("Content-Type must be application/vnd.api+json instead of " +
+                     request.content_type)
 
 
 def validate_resource_type(expected_type, data):


### PR DESCRIPTION
This has been broken from the start of this template.

`args` contains query params, not headers.
https://flask.palletsprojects.com/en/2.0.x/api/#flask.Request.content_type
starting a sting with a forward slash doesn't make it a regex either