### PR TITLE
Adds `/app` to the `PYTHONPATH`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Michaël Dierick "michael@dierick.io"
 
 # Gunicorn Docker config
 ENV MODULE_NAME web
-ENV PYTHONPATH "/usr/src/app"
+ENV PYTHONPATH "/usr/src/app:/app"
 ENV WEB_CONCURRENCY "1"
 
 # Overrides the start.sh used in `tiangolo/meinheld-gunicorn`


### PR DESCRIPTION
By having `/app` in the `PYTHONPATH`, users of the template should be
able to use absolute imports, as their modules will be placed inside
`PYTHONPATH`.