### PR TITLE
feat: follow the same JSON:API structure for errors as the JS template

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,10 @@ Validate whether the Content-Type header contains the JSONAPI `content-type`-hea
 Validate whether the type specified in the JSONAPI data is equal to the expected type. Returns a 409 otherwise.
 
 #### error(title, status="400", detail=None, id=None, links=None, code=None, source=None, meta=None)
-    Returns a JSONAPI compliant error [Response object](https://flask.palletsprojects.com/en/1.1.x/api/#response-objects) with the given status code (default: 400). Allowed keys are described by [JSONAPI error objects](https://jsonapi.org/format/#error-objects).
+
+Returns a JSONAPI compliant error [Response object](https://flask.palletsprojects.com/en/1.1.x/api/#response-objects) with the given status code (default: 400). Allowed keys are described by [JSONAPI error objects](https://jsonapi.org/format/#error-objects).
+    
+Other keywords are accepted and are merged into the error object but support for them is deprecated.
 
 #### query(query)
 

--- a/README.md
+++ b/README.md
@@ -89,9 +89,8 @@ Validate whether the Content-Type header contains the JSONAPI `content-type`-hea
 
 Validate whether the type specified in the JSONAPI data is equal to the expected type. Returns a 409 otherwise.
 
-#### error(title, status=400, **kwargs)
-
-Returns a JSONAPI compliant error [Response object](https://flask.palletsprojects.com/en/1.1.x/api/#response-objects) with the given status code (default: 400). `kwargs` can be any other keys supported by [JSONAPI error objects](https://jsonapi.org/format/#error-objects).
+#### error(title, status="400", detail=None, id=None, links=None, code=None, source=None, meta=None)
+    Returns a JSONAPI compliant error [Response object](https://flask.palletsprojects.com/en/1.1.x/api/#response-objects) with the given status code (default: 400). Allowed keys are described by [JSONAPI error objects](https://jsonapi.org/format/#error-objects).
 
 #### query(query)
 

--- a/helpers.py
+++ b/helpers.py
@@ -48,12 +48,21 @@ def rewrite_url_header(request):
     return request.headers.get('X-REWRITE-URL')
 
 
-def error(msg, status=400, **kwargs):
+def error(title, status="400", detail=None, id=None, links=None, code=None, source=None, meta=None):
     """Returns a Response object containing a JSONAPI compliant error response
-    with the given status code (400 by default)."""
-    error_obj = kwargs
-    error_obj["title"] = msg
-    error_obj["status"] = status
+    with the given status code (400 by default).
+
+    See https://jsonapi.org/format/#error-objects for desired structure."""
+    error_obj = {
+        "title": title,
+        "status": status
+    }
+    if detail is not None: error_obj["detail"] = detail
+    if id is not None: error_obj["id"] = id
+    if links is not None: error_obj["links"] = links
+    if code is not None: error_obj["code"] = code
+    if source is not None: error_obj["source"] = source
+    if meta is not None: error_obj["meta"] = meta
     response = jsonify({
         "errors": [error_obj]
     })

--- a/helpers.py
+++ b/helpers.py
@@ -48,7 +48,7 @@ def rewrite_url_header(request):
     return request.headers.get('X-REWRITE-URL')
 
 
-def error(title, status="400", detail=None, id=None, links=None, code=None, source=None, meta=None):
+def error(title, status="400", detail=None, id=None, links=None, code=None, source=None, meta=None, **kwargs):
     """Returns a Response object containing a JSONAPI compliant error response
     with the given status code (400 by default).
 
@@ -57,6 +57,14 @@ def error(title, status="400", detail=None, id=None, links=None, code=None, sour
         "title": title,
         "status": status
     }
+
+    for key, value in kwargs.items():
+        print("[DEPRECATION] Supplying args not supported by jsonapi to error helper is deprecated and support will be removed, received {} => {}".format(key, value), flush=True)
+        error_obj[key] = value
+
+    for kwarg, values in kwargs.items():
+        print( "{} => {}".format( kwarg, values ) )
+
     if detail is not None: error_obj["detail"] = detail
     if id is not None: error_obj["id"] = id
     if links is not None: error_obj["links"] = links

--- a/helpers.py
+++ b/helpers.py
@@ -52,7 +52,7 @@ def error(msg, status=400, **kwargs):
     """Returns a Response object containing a JSONAPI compliant error response
     with the given status code (400 by default)."""
     error_obj = kwargs
-    error_obj["detail"] = msg
+    error_obj["title"] = msg
     error_obj["status"] = status
     response = jsonify({
         "errors": [error_obj]


### PR DESCRIPTION
In the [JS template](https://github.com/mu-semtech/mu-javascript-template/blob/master/helpers/mu/server.js#L30-L35) errors get a message passed in which is returned as the title field of the JSON:API response object.

Note that the JS template should also pass status as a member of the error object, as happens here in the Python template, but it currently doesn't.