### PR TITLE
fix: install the service provided requirements on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ curl localhost:8080/hello
 
 ### Dependencies
 
-If your service needs external libraries other than the ones already provided by the template (Flask, SPARQLWrapper and rdflib), you can specify those in a [`requirements.txt`](https://pip.pypa.io/en/stable/reference/requirements-file-format/)-file. The template will take care of installing them when you build your Docker image.
+If your service needs external libraries other than the ones already provided by the template (Flask, SPARQLWrapper and rdflib), you can specify those in a [`requirements.txt`](https://pip.pypa.io/en/stable/reference/requirements-file-format/)-file. The template will take care of installing them when you build your Docker image and when you boot the template in development mode for the first time.
 
 ### Development mode
 

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 set -eu
 if [ ${MODE:-""} == "development" ]; then 
-    if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    if [ -f /app/requirements.txt ]; then pip install -r /app/requirements.txt; fi
     exec python web.py
 else 
     exec gunicorn -k egg:meinheld#gunicorn_worker -c "$GUNICORN_CONF" "$APP_MODULE"


### PR DESCRIPTION
Re-run the installation of dependencies specified by the service each time the service boots in DEV mode. This was already implemented, but the service tries to re-install the template dependencies (which is redundant because those don't change).