### PR TITLE
Exception handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ my-python:
 
 - `MODE` to specify the deployment mode. Can be `development` as well as `production`. Defaults to `production`
 
+- `LOG_EXCEPTIONS` set to any value to add a catch-all Flask errorhandler that logs exceptions rather than just returning them, to aid with debugging. Is not on by default in development as it may prevent custom errorhandlers in you app from being reached.
+
 - `MU_SPARQL_ENDPOINT` is used to configure the SPARQL endpoint.
 
   - By default this is set to `http://database:8890/sparql`. In that case the triple store used in the backend should be linked to the microservice container as `database`.

--- a/web.py
+++ b/web.py
@@ -29,8 +29,8 @@ app_file = os.environ.get('APP_ENTRYPOINT')
 try:
     module_path = 'ext.app.{}'.format(app_file)
     import_module(module_path)
-except Exception as e:
-    helpers.log(str(e))
+except Exception:
+    helpers.logger.exception('Exception raised when importing app code')
 
 #######################
 ## Start Application ##

--- a/web.py
+++ b/web.py
@@ -32,6 +32,12 @@ try:
 except Exception:
     helpers.logger.exception('Exception raised when importing app code')
 
+if os.environ.get('LOG_EXCEPTIONS'):
+    @app.errorhandler(Exception)
+    def handle_exception(e):
+        helpers.logger.exception('Unhandled exception raised in route, returning 500')
+        raise e
+
 #######################
 ## Start Application ##
 #######################


### PR DESCRIPTION
The existing start-up error handling simply logs the string message from the exception which doesn't always help, so instead, pull the stack trace using the traceback module and log it.

When debugging an endpoint that the delta-notifier was calling, I realised that an exception in a route is just returned to the caller, not logged, so this adds an environment variable to enable a catch-all handler, which logs the stack trace but re-raises the exception so it doesn't change the behaviour.