### PR TITLE
add env var that controls query logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN chmod +x /start.sh
 # Template config
 ENV APP_ENTRYPOINT web
 ENV LOG_LEVEL info
+ENV LOG_SPARQL_ALL True
 ENV MU_SPARQL_ENDPOINT 'http://database:8890/sparql'
 ENV MU_SPARQL_UPDATEPOINT 'http://database:8890/sparql'
 ENV MU_APPLICATION_GRAPH 'http://mu.semte.ch/application'

--- a/helpers.py
+++ b/helpers.py
@@ -42,6 +42,8 @@ logger.addHandler(fileHandler)
 consoleHandler = logging.StreamHandler(stream=sys.stdout)# or stderr?
 logger.addHandler(consoleHandler)
 
+LOG_SPARQL_ALL = os.environ.get('LOG_SPARQL_ALL') in ('TRUE', 'True', 'true')
+
 def generate_uuid():
     """Generates a random unique user id (UUID) based on the host ID and current time"""
     return str(uuid.uuid1())
@@ -119,7 +121,6 @@ MU_HEADERS = [
 
 def query(the_query):
     """Execute the given SPARQL query (select/ask/construct) on the triplestore and returns the results in the given return Format (JSON by default)."""
-    log("execute query: \n" + the_query)
     for header in MU_HEADERS:
         if header in request.headers:
             sparqlQuery.customHttpHeaders[header] = request.headers[header]
@@ -127,6 +128,8 @@ def query(the_query):
             if header in sparqlQuery.customHttpHeaders:
                 del sparqlQuery.customHttpHeaders[header]
     sparqlQuery.setQuery(the_query)
+    if LOG_SPARQL_ALL:
+        log("execute query: \n" + the_query)
     return sparqlQuery.query().convert()
 
 
@@ -140,6 +143,8 @@ def update(the_query):
                 del sparqlUpdate.customHttpHeaders[header]
     sparqlUpdate.setQuery(the_query)
     if sparqlUpdate.isSparqlUpdateRequest():
+        if LOG_SPARQL_ALL:
+            log("execute query: \n" + the_query)
         sparqlUpdate.query()
 
 


### PR DESCRIPTION
Partial implementation of the JS service functionality wrt logging control. Allows at least silencing query logging in environments where you don't want/need it and adds logging that was previously missing on `update` queries.