### PR TITLE
Feature/use gunicorn in dev mode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 SPARQLWrapper
 rdflib
+inotify

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 set -eu
 if [ ${MODE:-""} == "development" ]; then 
     if [ -f /app/requirements.txt ]; then pip install -r /app/requirements.txt; fi
-    exec gunicorn -k egg:meinheld#gunicorn_worker -c "$GUNICORN_CONF" "$APP_MODULE"
+    exec gunicorn -k --reload egg:meinheld#gunicorn_worker -c "$GUNICORN_CONF" "$APP_MODULE"
 else 
     exec gunicorn -k egg:meinheld#gunicorn_worker -c "$GUNICORN_CONF" "$APP_MODULE"
 fi

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 set -eu
 if [ ${MODE:-""} == "development" ]; then 
     if [ -f /app/requirements.txt ]; then pip install -r /app/requirements.txt; fi
-    exec python web.py
+    exec gunicorn -k egg:meinheld#gunicorn_worker -c "$GUNICORN_CONF" "$APP_MODULE"
 else 
     exec gunicorn -k egg:meinheld#gunicorn_worker -c "$GUNICORN_CONF" "$APP_MODULE"
 fi

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 set -eu
 if [ ${MODE:-""} == "development" ]; then 
     if [ -f /app/requirements.txt ]; then pip install -r /app/requirements.txt; fi
-    exec gunicorn -k --reload egg:meinheld#gunicorn_worker -c "$GUNICORN_CONF" "$APP_MODULE"
+    exec gunicorn -k gthread --reload -c "$GUNICORN_CONF" "$APP_MODULE"
 else 
-    exec gunicorn -k egg:meinheld#gunicorn_worker -c "$GUNICORN_CONF" "$APP_MODULE"
+    exec gunicorn -k gthread -c "$GUNICORN_CONF" "$APP_MODULE"
 fi

--- a/web.py
+++ b/web.py
@@ -28,10 +28,3 @@ builtins.sparql_escape = sparql_escape
 app_file = os.environ.get('APP_ENTRYPOINT')
 module_path = 'ext.app.{}'.format(app_file)
 import_module(module_path)
-
-#######################
-## Start Application ##
-#######################
-if __name__ == '__main__':
-    debug = os.environ.get('MODE') == "development"
-    app.run(debug=debug, host='0.0.0.0', port=80)

--- a/web.py
+++ b/web.py
@@ -26,11 +26,8 @@ builtins.sparql_escape = sparql_escape
 
 # Import the app from the service consuming the template
 app_file = os.environ.get('APP_ENTRYPOINT')
-try:
-    module_path = 'ext.app.{}'.format(app_file)
-    import_module(module_path)
-except Exception as e:
-    helpers.log(str(e))
+module_path = 'ext.app.{}'.format(app_file)
+import_module(module_path)
 
 #######################
 ## Start Application ##


### PR DESCRIPTION
This PR changes the template so that the same mechanism (gunicorn) that is used for running in production is also used in development mode. This should ensure that the behaviour of services using this template is consistent between development mode and production mode.

### Why

With the previous setup, in development mode the template would use Flask to serve the code, which meant that route handlers can take as long as you want, whereas in production mode there's a timeout for workers set by Gunicorn, so a route handler can't take more than a certain amount of time before it gets aborted.
This disparity is quite annoying because you might make something that works perfectly locally in dev-mode and then as soon as you deploy it you notice it breaks with errors you can't seem to reproduce locally.

### How

Gunicorn provides a `--reload` option so that we don't lose the live code reload functionality of the template, but to get this working it was necessary to replace the worker class. It seems that the workers we used [`meinheld`](https://github.com/mopemope/meinheld) don't work well alongside gunicorn's reload mechanism: notice that in [this](https://github.com/benoitc/gunicorn/issues/1562) issue the reporter is using meinheld workers. Meinheld itself also seems quite unmaintained, as the last commit for it was over 3 years ago and its [official website](https://meinheld.org) has been squatted, so it might make sense to replace the worker class regardless.

> [!WARNING]
> I know next to nothing about Gunicorn's architecture and the working of WSGI servers. I'm not really sure if the suggested worker is "better" than what we're currently using. So thorough testing with existing services is needed before merging this.

### Nice extras

A lot of our services make use of [`apscheduler`](https://github.com/agronholm/apscheduler) to build cronjobs. Due to how Flask's debug mode interacted with this library, in development mode usage of this library would result in 2 schedulers being instantiated. Every cron job would run twice. Although this didn't happen in production mode, it could be quite annoying/confusing when developing using this template. Switching to gunicorn for development mode has inadvertently resolved this. For some extra context see [this StackOverflow post](https://stackoverflow.com/questions/14874782/apscheduler-in-flask-executes-twice).

### Encountered issues

Gunicorn's `--reload` mechanism seems to be broken for certain errors: https://github.com/benoitc/gunicorn/issues/2244
This would mean that the reloader stops working if there's e.g. a syntax error in your file while developing a service, which is quite likely to happen. To be determined if this gets fixed if we use a newer version of gunicorn (the currently used version is 2 years old). ~~Adding `inotify` enables that mechanism for the reloader, in which case it can survive the mentioned errors.~~
By changing the service-code import mechanism we can circumvent this issue. The reloader tracks the files it needs to listen to based on imports. Because we used to set the import inside a try-except block, the reloader wouldn't correctly pick up file changes if importing the file throws. By moving this import outside of the try-except block, we keep the reloader happy and also "fix" https://github.com/mu-semtech/mu-python-template/issues/12: a missing dependency or a syntax error in service-code will not silently print a single log line and set up a web server with no endpoints, instead it crashes the service.