### PR TITLE
Refactor Woodpecker pipeline configs

### DIFF
--- a/.woodpecker/.feature.yml
+++ b/.woodpecker/.feature.yml
@@ -5,6 +5,6 @@ pipeline:
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME}"
       tags: "feature-${CI_COMMIT_BRANCH##feature/}"
     secrets: [docker_username, docker_password]
-    when:
-      event: push
-      branch: feature/*
+when:
+  event: push
+  branch: feature/*

--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -5,6 +5,6 @@ pipeline:
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME}"
       tags: latest
     secrets: [docker_username, docker_password]
-    when:
-      event: push
-      branch: [master, main]
+when:
+  event: push
+  branch: [master, main]

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -5,6 +5,6 @@ pipeline:
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME}"
       tags: "${CI_COMMIT_TAG##v}"
     secrets: [ docker_username, docker_password ]
-    when:
-      event: tag
-      tag: v*
+when:
+  event: tag
+  tag: v*


### PR DESCRIPTION
This PR sets the pipeline event conditions at root level. By moving the conditions to the root level, we ensure that the pipelines are only ran when the applicable conditions are met.

The current setup will run three pipelines no matter what (and clone the repo thrice), but possibly do nothing afterwards. With the new setup we will e.g. not run the feature-pipeline when pushing a tag.