### PR TITLE
specify version of python in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mu Python template
 
-Template for [mu.semte.ch](http://mu.semte.ch)-microservices written in Python3. Based on the [Flask](https://palletsprojects.com/p/flask/)-framework.
+Template for [mu.semte.ch](http://mu.semte.ch)-microservices written in Python3.8. Based on the [Flask](https://palletsprojects.com/p/flask/)-framework.
 
 ## Quickstart
 


### PR DESCRIPTION
Not sure if this is the best place, but as the version can be important (for libraries and specific python features), it should at least be referenced in the readme somewhere.

It might be good to also add this version in the release tags, in case the version gets bumped in the future, but a specific version is needed for a service.