### PR TITLE
Startup the flask dev server the correct way

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 set -eu
 if [ ${MODE:-""} == "development" ]; then 
     if [ -f /app/requirements.txt ]; then pip install -r /app/requirements.txt; fi
-    exec python web.py
+    exec flask --app web.py run --debug --port 80 --host "0.0.0.0"
 else 
     exec gunicorn -k egg:meinheld#gunicorn_worker -c "$GUNICORN_CONF" "$APP_MODULE"
 fi

--- a/web.py
+++ b/web.py
@@ -26,11 +26,8 @@ builtins.sparql_escape = sparql_escape
 
 # Import the app from the service consuming the template
 app_file = os.environ.get('APP_ENTRYPOINT')
-try:
-    module_path = 'ext.app.{}'.format(app_file)
-    import_module(module_path)
-except Exception:
-    helpers.logger.exception('Exception raised when importing app code')
+module_path = 'ext.app.{}'.format(app_file)
+import_module(module_path)
 
 #######################
 ## Start Application ##


### PR DESCRIPTION
As indicated in the Flask documentation (https://flask.palletsprojects.com/en/2.3.x/server/#in-code) `app.run` is not the best way to run the flask dev server. It is better to run as `flask run`. This does not crash the server on errors, instead it logs and returns the error and stacktrace.