### PR TITLE
safer comparison of MODE env var

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 set -eu
-if [ ${MODE:-""} == "development" ]; then 
+if [ "${MODE}" == "development" ]; then 
     if [ -f /app/requirements.txt ]; then pip install -r /app/requirements.txt; fi
     exec python web.py
 else 


### PR DESCRIPTION
fixes #22 

As mentioned there  in the current setup one would still have the sh parser trip over a use case like
```
export MODE="my mode"
./start.sh: line 4: [: too many arguments
```