### PR TITLE
chore: log queries when failing

### DIFF
--- a/.woodpecker/.feature.yml
+++ b/.woodpecker/.feature.yml
@@ -1,10 +1,13 @@
-pipeline:
+steps:
   build-and-push:
-    image: plugins/docker
+    image: woodpeckerci/plugin-docker-buildx
     settings:
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME}"
       tags: "feature-${CI_COMMIT_BRANCH##feature/}"
-    secrets: [docker_username, docker_password]
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
-  event: push
-  branch: feature/*
+  - event: push
+    branch: [feature/*]

--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -1,10 +1,13 @@
-pipeline:
+steps:
   build-and-push:
-    image: plugins/docker
+    image: woodpeckerci/plugin-docker-buildx
     settings:
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME}"
       tags: latest
-    secrets: [docker_username, docker_password]
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
-  event: push
+  - event: push
   branch: [master, main]

--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -10,4 +10,4 @@ steps:
         from_secret: docker_password
 when:
   - event: push
-  branch: [master, main]
+    branch: [master, main]

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -7,4 +7,4 @@ pipeline:
     secrets: [ docker_username, docker_password ]
 when:
   event: tag
-  tag: v*
+  ref: refs/tags/v*

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -1,10 +1,13 @@
-pipeline:
+steps:
   release:
-    image: plugins/docker
+    image: woodpeckerci/plugin-docker-buildx
     settings:
       repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME}"
       tags: "${CI_COMMIT_TAG##v}"
-    secrets: [ docker_username, docker_password ]
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
-  event: tag
-  ref: refs/tags/v*
+  - event: tag
+    ref: refs/tags/v*

--- a/escape_helpers.py
+++ b/escape_helpers.py
@@ -53,7 +53,7 @@ def sparql_escape_int(obj):
 
 def sparql_escape_float(obj):
     """Converts the given float to a SPARQL-safe RDF object string with the right RDF-datatype. """
-    if not isinstance(obj, int):
+    if not isinstance(obj, float):
         warn("You are escaping something that isn't a float with \
         the 'sparql_escape_float'-method. Implicit casting will occurr.")
         obj = str(float(obj))

--- a/helpers.py
+++ b/helpers.py
@@ -138,7 +138,11 @@ def query(the_query):
     sparqlQuery.setQuery(the_query)
     if LOG_SPARQL_QUERIES:
         log("Execute query: \n" + the_query)
-    return sparqlQuery.query().convert()
+    try:
+        return sparqlQuery.query().convert()
+    except Exception as e:
+        log("Failed Query: \n" + the_query)
+        raise e
 
 
 def update(the_query):
@@ -153,7 +157,11 @@ def update(the_query):
     if sparqlUpdate.isSparqlUpdateRequest():
         if LOG_SPARQL_UPDATES:
             log("Execute query: \n" + the_query)
-        sparqlUpdate.query()
+        try:
+            sparqlUpdate.query()
+        except Exception as e:
+            log("Failed Query: \n" + the_query)
+            raise e
 
 
 def update_modified(subject, modified=datetime.datetime.now()):

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 set -eu
-if [ ${MODE:-""} == "development" ]; then 
+if [ "${MODE}" == "development" ]; then 
     if [ -f /app/requirements.txt ]; then pip install -r /app/requirements.txt; fi
     exec python web.py
 else 


### PR DESCRIPTION
Logs queries when they result in an exception being thrown. Chatty services can then disable `LOG_SPARQL_ALL` or `LOG_SPARQL_{QUERIES,UPDATES}` but still see queries that result in failures for some hopefully easier debugging.

Note:
This can result in double-logging queries (if the logging env vars are enabled) but this is in-line with how the mu-auth-sudo JS package does it.

Currently available on Docker Hub as [`sergiofenoll/mu-python-template:latest`](https://hub.docker.com/layers/sergiofenoll/mu-python-template/latest/images/sha256-de56346f25bbcd800a4765cb18e691fab571017540c3a0813598d31da5499893). Can be used while waiting for this to be merged, tagged and released, or while waiting for a feature branch to be released on this repo.