### PR TITLE
Pin the dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask
-SPARQLWrapper
-rdflib
+Flask==3.0.3
+SPARQLWrapper==2.0.0
+rdflib==7.1.4


### PR DESCRIPTION
I think this could avoid subtle build problems.

Not sure if it will cover all cases. E.g. if unpinned depencies are used elsewhere down the line.