### PR TITLE
Proposal to update the python version to 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiangolo/meinheld-gunicorn:python3.8
+FROM tiangolo/meinheld-gunicorn:python3.9
 LABEL maintainer="team@semantic.works"
 
 # Gunicorn Docker config


### PR DESCRIPTION
Proposal to use a newer version of python. This would allow the usage of more recent versions of popular AI (NLP) libraries such as:
- [Huggingface Transformers](https://github.com/huggingface/transformers)
- [NLTK](https://github.com/nltk/nltk)
- [Flair](https://github.com/flairNLP/flair)

These libraries require Python 3.9 or higher.

