### PR TITLE
Update to FastAPI & Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,31 @@
-FROM tiangolo/meinheld-gunicorn:python3.8
+FROM python:3.12-slim
 LABEL maintainer="team@semantic.works"
 
-# Gunicorn Docker config
-ENV MODULE_NAME web
-ENV PYTHONPATH "/usr/src/app:/app"
-ENV WEB_CONCURRENCY "1"
+ENV MODULE_NAME=web
+ENV PYTHONPATH="/usr/src/app:/app"
+ENV WEB_CONCURRENCY="1"
 
-# Overrides the start.sh used in `tiangolo/meinheld-gunicorn`
-COPY ./start.sh /start.sh
-RUN chmod +x /start.sh
-
+COPY ./start.sh /root/start.sh
+RUN chmod +x /root/start.sh
 
 # Template config
-ENV APP_ENTRYPOINT web
-ENV LOG_LEVEL info
-ENV LOG_SPARQL_ALL True
-ENV MU_SPARQL_ENDPOINT 'http://database:8890/sparql'
-ENV MU_SPARQL_UPDATEPOINT 'http://database:8890/sparql'
-ENV MU_APPLICATION_GRAPH 'http://mu.semte.ch/application'
-ENV MODE 'production'
+ENV APP_ENTRYPOINT=web
+ENV LOG_LEVEL=info
+ENV LOG_SPARQL_ALL=True
+ENV MU_SPARQL_ENDPOINT='http://database:8890/sparql'
+ENV MU_SPARQL_UPDATEPOINT='http://database:8890/sparql'
+ENV MU_APPLICATION_GRAPH='http://mu.semte.ch/application'
+ENV MODE='production'
 
-RUN mkdir -p /usr/src/app
+RUN mkdir -p /usr/src/app && mkdir /logs
 WORKDIR /usr/src/app
 ADD . /usr/src/app
 
 RUN ln -s /app /usr/src/app/ext \
      && cd /usr/src/app \
-     && pip3 install -r requirements.txt
+     && pip install -r requirements.txt
 
+CMD [ "/root/start.sh" ]
 ONBUILD ADD Dockerfile requirement[s].txt /app/
 ONBUILD RUN cd /app/ \
     && if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mu Python template
 
-Template for [mu.semte.ch](http://mu.semte.ch)-microservices written in Python3.8. Based on the [Flask](https://palletsprojects.com/p/flask/)-framework.
+Template for [mu.semte.ch](http://mu.semte.ch)-microservices written in Python3.8. Based on the [FastAPI](https://fastapi.tiangolo.com/)-framework.
 
 ## Quickstart
 
@@ -12,8 +12,11 @@ LABEL maintainer="maintainer@example.com"
 
 Create a `web.py` entrypoint-file. (naming of the entrypoint can be configured through `APP_ENTRYPOINT`)
 ```python
-@app.route("/hello")
-def hello():
+from starlette.responses import PlainTextResponse
+
+
+@app.get("/hello")
+def hello() -> PlainTextResponse:
     return "Hello from the mu-python-template!"
 ```
 
@@ -76,19 +79,6 @@ def log(msg, *args, **kwargs)
 > 
 > Note that the `helpers` module also exposes `logger`, which is the logger instance (https://docs.python.org/3/library/logging.html#logger-objects) 
 > used by the template. The methods provided by this instance can be used for more fine-grained logging.
-
-<a id="helpers.error"></a>
-
-#### `error`
-
-```python
-def error(msg, status=400, **kwargs)
-```
-
-> Returns a Response object containing a JSONAPI compliant error response with the given status code (400 by default).
-> 
-> Response object documentation: https://flask.palletsprojects.com/en/1.1.x/api/#response-objects
-> The kwargs can be any other key supported by JSONAPI error objects: https://jsonapi.org/format/#error-objects
 
 <a id="helpers.session_id_header"></a>
 

--- a/helpers.py
+++ b/helpers.py
@@ -3,10 +3,12 @@ import datetime
 import logging
 import os
 import sys
-from flask import jsonify, request
+from fastapi import Request
+from jsonapi_pydantic.v1_0 import Error, TopLevel
 from rdflib.namespace import DC
 from escape_helpers import sparql_escape
 from SPARQLWrapper import SPARQLWrapper, JSON
+from fastapi.responses import Response
 
 """
 The template provides the user with several helper methods. They aim to give you a step ahead for:
@@ -69,24 +71,6 @@ def log(msg, *args, **kwargs):
     """
     return logger.info(msg, *args, **kwargs)
 
-def error(msg, status=400, **kwargs):
-    """
-    Returns a Response object containing a JSONAPI compliant error response with the given status code (400 by default).
-
-    Response object documentation: https://flask.palletsprojects.com/en/1.1.x/api/#response-objects
-    The kwargs can be any other key supported by JSONAPI error objects: https://jsonapi.org/format/#error-objects
-    """
-    error_obj = kwargs
-    error_obj["detail"] = msg
-    error_obj["status"] = status
-    response = jsonify({
-        "errors": [error_obj]
-    })
-    response.status_code = error_obj["status"]
-    response.headers["Content-Type"] = "application/vnd.api+json"
-    return response
-
-
 
 def session_id_header(request):
     """Returns the MU-SESSION-ID header from the given requests' headers"""
@@ -127,10 +111,10 @@ MU_HEADERS = [
     "MU-AUTH-USED-GROUPS"
 ]
 
-def query(the_query):
+def query(the_query: str, request: Request | None = None):
     """Execute the given SPARQL query (select/ask/construct) on the triplestore and returns the results in the given return Format (JSON by default)."""
     for header in MU_HEADERS:
-        if header in request.headers:
+        if request is not None and header in request.headers:
             sparqlQuery.customHttpHeaders[header] = request.headers[header]
         else: # Make sure headers used for a previous query are cleared
             if header in sparqlQuery.customHttpHeaders:
@@ -145,10 +129,10 @@ def query(the_query):
         raise e
 
 
-def update(the_query):
+def update(the_query: str, request: Request | None = None):
     """Execute the given update SPARQL query on the triplestore. If the given query is not an update query, nothing happens."""
     for header in MU_HEADERS:
-        if header in request.headers:
+        if request is not None and header in request.headers:
             sparqlUpdate.customHttpHeaders[header] = request.headers[header]
         else: # Make sure headers used for a previous query are cleared
             if header in sparqlUpdate.customHttpHeaders:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
-flask
+fastapi
+uvicorn
 SPARQLWrapper
 rdflib
+jsonapi-pydantic

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,10 @@
 #! /usr/bin/env bash
 set -eu
+opts="${MODULE_NAME}:app --host 0.0.0.0 --port 80 --proxy-headers --timeout-keep-alive 300 --workers ${WEB_CONCURRENCY}"
+
 if [ "${MODE}" == "development" ]; then 
     if [ -f /app/requirements.txt ]; then pip install -r /app/requirements.txt; fi
-    exec flask --app web.py run --debug --port 80 --host "0.0.0.0"
-else 
-    exec gunicorn -k egg:meinheld#gunicorn_worker -c "$GUNICORN_CONF" "$APP_MODULE"
+    opts+=" --reload"
 fi
+
+exec uvicorn $opts

--- a/web.py
+++ b/web.py
@@ -2,14 +2,34 @@ import os
 from importlib import import_module
 import builtins
 
-import flask
+from fastapi import FastAPI
+from fastapi.responses import Response
+from jsonapi_pydantic.v1_0 import Error, TopLevel
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from rdflib.namespace import Namespace
 
 import helpers
 from escape_helpers import sparql_escape
 
 # WSGI variable name used by the server
-app = flask.Flask(__name__)
+app = FastAPI()
+
+
+@app.exception_handler(StarletteHTTPException)
+async def http_exception_handler(request, exc):
+    error_object = TopLevel(
+        errors=[
+            Error(
+                detail=str(exc.detail),
+                status=exc.status_code
+            )
+        ]
+    )
+    return Response(
+        content=error_object.model_dump_json(), status_code=exc.status_code, headers={
+            'Content-Type': 'application/vnd.api+json'
+        }
+    )
 
 ##################
 ## Vocabularies ##
@@ -28,10 +48,3 @@ builtins.sparql_escape = sparql_escape
 app_file = os.environ.get('APP_ENTRYPOINT')
 module_path = 'ext.app.{}'.format(app_file)
 import_module(module_path)
-
-#######################
-## Start Application ##
-#######################
-if __name__ == '__main__':
-    debug = os.environ.get('MODE') == "development"
-    app.run(debug=debug, host='0.0.0.0', port=80)


### PR DESCRIPTION
Modernization of the template based on FastAPI and a more recent python version. 
- Based of python:3.12-slim default container, as highlighted [here](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker)
- Got rid of the error() helper, FastAPIs scheme for error handling is to throw basic HTTPExceptions, if required override the handler (which we did here). Note, its possible to register handlers for other types of exceptions as well making this mechanism very flexible
- updated dockerfile and start.sh
- use uvicorn (fastapi default)