### PR TITLE
Add support for on-build script to execute during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,13 @@ RUN ln -s /app /usr/src/app/ext \
      && cd /usr/src/app \
      && pip3 install -r requirements.txt
 
-ONBUILD ADD Dockerfile requirement[s].txt /app/
+ONBUILD ADD Dockerfile requirement[s].txt on-build.sh* /app/
+ONBUILD RUN if [ -f /app/on-build.sh ]; \
+     then \
+        echo "Running custom on-build.sh of child" \
+        && chmod +x /app/on-build.sh \
+        && /bin/bash /app/on-build.sh ;\
+     fi
 ONBUILD RUN cd /app/ \
     && if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 

--- a/README.md
+++ b/README.md
@@ -347,3 +347,6 @@ python3 -m pip install pydoc-markdown
 python3 README.py
 ```
 You can customise the output through the API configuration! See [README.py](README.py) && the [pydoc-markdown docs](https://niklasrosenstein.github.io/pydoc-markdown/).
+
+### Custom build commands
+To execute custom bash statements during the image build (e.g. to install aditional system libraries), provide an `on-build.sh` script in the root of your service. It will be automatically picked up and executed by the Docker build.


### PR DESCRIPTION
In-line with on-build support of mu-javascript-template and mu-ruby-template