### PR TITLE
add thread safeness, sudo queries and wait_for_triplestore

### DIFF
--- a/.woodpecker/.feature.yml
+++ b/.woodpecker/.feature.yml
@@ -2,8 +2,9 @@ steps:
   build-and-push:
     image: woodpeckerci/plugin-docker-buildx
     settings:
-      repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME}"
-      tags: "feature-${CI_COMMIT_BRANCH##feature/}"
+      platforms: linux/amd64,linux/arm64
+      repo: '${CI_REPO_OWNER##mu-}/${CI_REPO_NAME}'
+      tags: 'feature-${CI_COMMIT_BRANCH##feature/}'
       username:
         from_secret: docker_username
       password:

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -2,8 +2,9 @@ steps:
   release:
     image: woodpeckerci/plugin-docker-buildx
     settings:
-      repo: "${CI_REPO_OWNER##mu-}/${CI_REPO_NAME}"
-      tags: "${CI_COMMIT_TAG##v}"
+      platforms: linux/amd64,linux/arm64
+      repo: '${CI_REPO_OWNER##mu-}/${CI_REPO_NAME}'
+      tags: '${CI_COMMIT_TAG##v}'
       username:
         from_secret: docker_username
       password:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ apt update && apt install -y libgeos-dev
 
 ### Development mode
 
-By leveraging Dockers' [bind-mount](https://docs.docker.com/storage/bind-mounts/), you can mount your application code into an existing service image. This spares you from building a new image to test each change. Just mount your services' folder to the containers' `/app`. On top of that, you can configure the environment variable `MODE` to `development`. That enables live-reloading of the server, so it immediately updates when you save a file.  
+By leveraging Dockers' [bind-mount](https://docs.docker.com/storage/bind-mounts/), you can mount your application code into an existing service image. This spares you from building a new image to test each change. Just mount your services' folder to the containers' `/app`. On top of that, you can configure the environment variable `MODE` to `development`. That enables live-reloading of the server, so it immediately updates when you save a file.
 
 example docker-compose parameters:
 ```yml
@@ -82,11 +82,11 @@ def log(msg, *args, **kwargs)
 ```
 
 > Write a log message to the log file.
-> 
+>
 > Works exactly the same as the logging.info (https://docs.python.org/3/library/logging.html#logging.info) method from pythons' logging module.
-> Logs are written to the /logs directory in the docker container.  
-> 
-> Note that the `helpers` module also exposes `logger`, which is the logger instance (https://docs.python.org/3/library/logging.html#logger-objects) 
+> Logs are written to the /logs directory in the docker container.
+>
+> Note that the `helpers` module also exposes `logger`, which is the logger instance (https://docs.python.org/3/library/logging.html#logger-objects)
 > used by the template. The methods provided by this instance can be used for more fine-grained logging.
 
 <a id="helpers.session_id_header"></a>
@@ -134,10 +134,15 @@ def validate_resource_type(expected_type, data)
 #### `query`
 
 ```python
-def query(the_query)
+def query(the_query, request = None, thread_safe = False, sudo = False )
 ```
 
 > Execute the given SPARQL query (select/ask/construct) on the triplestore and returns the results in the given return Format (JSON by default).
+>
+> Advanced options:
+> - request: pass in the original request to add in MU-SESSION-ID, MU-CALL-ID, MU-AUTH-ALLOWED-GROUPS, MU-AUTH-USED-GROUPS headers to the sparql request
+> - thread_safe: you may configure fastapi to use multiple worker threads and still use sudo or request to modify the sparql request's http headers. If so, use thread_safe to create a new sparql client every time to avoid contamination of the sparqlQuery object by other threads. Slight performance loss, but hey, you got threads!
+> - sudo: perform a sudo query, ignoring the groups of the originating
 
 <a id="helpers.update"></a>
 
@@ -148,6 +153,11 @@ def update(the_query)
 ```
 
 > Execute the given update SPARQL query on the triplestore. If the given query is not an update query, nothing happens.
+>
+> Advanced options:
+> - request: pass in the original request to add in MU-SESSION-ID, MU-CALL-ID, MU-AUTH-ALLOWED-GROUPS, MU-AUTH-USED-GROUPS headers to the sparql request
+> - thread_safe: you may configure fastapi to use multiple worker threads and still use sudo or request to modify the sparql request's http headers. If so, use thread_safe to create a new sparql client every time to avoid contamination of the sparqlQuery object by other threads. Slight performance loss, but hey, you got threads!
+> - sudo: perform a sudo query, ignoring the groups of the originating request
 
 <a id="helpers.update_modified"></a>
 
@@ -248,12 +258,12 @@ def sparql_escape_uri(obj)
 def sparql_escape(obj)
 ```
 
-> Converts the given object to a SPARQL-safe RDF object string with the right RDF-datatype. 
-> 
+> Converts the given object to a SPARQL-safe RDF object string with the right RDF-datatype.
+>
 > These functions should be used especially when inserting user-input to avoid SPARQL-injection.
 > Separate functions are available for different python datatypes.
 > The `sparql_escape` function however can automatically select the right method to use, for the following Python datatypes:
-> 
+>
 > - `str`
 > - `int`
 > - `float`
@@ -261,8 +271,16 @@ def sparql_escape(obj)
 > - `datetime.date`
 > - `datetime.time`
 > - `boolean`
-> 
+>
 > The `sparql_escape_uri`-function can be used for escaping URI's.
+
+#### `wait_for_triplestore`
+
+```python
+def wait_for_triplestore()
+```
+
+> Wait until the triplestore is running. Performs a sudo select query with limit 1 until it gets a proper result from the triplestore
 
 ### Writing SPARQL Queries
 
@@ -286,6 +304,19 @@ WHERE {
 """)
 query_string = query_template.substitute(person=sparql_escape_uri(my_person))
 query_result = query(query_string)
+```
+
+### Functions on startup
+Because of the way FastApi works, logic that should be run on startup should always be wrapped with an `@app.on_evente("startup")` decorator. For instance:
+
+```py
+@app.on_event("startup")
+async def startup_event():
+    wait_for_triplestore()
+    # on startup fail existing busy tasks
+    fail_busy_and_scheduled_tasks()
+    # on startup also immediately start scheduled tasks
+    process_open_tasks()
 ```
 
 ## Deployment
@@ -342,7 +373,7 @@ python3 README.py
 ```
 You can customise the output through the API configuration! See [README.py](README.py) && the [pydoc-markdown docs](https://niklasrosenstein.github.io/pydoc-markdown/).
 
-## Migate from Flask based versions
+## Migrate from Flask based versions
 Previous versions of this template were based on Flask. Effort was made to keep as much backward compatible as possible.
 However, some things were slightly modified or require your attention
 
@@ -388,3 +419,6 @@ always be declared as synchronous methods (no async in front!). This might make 
 on computationally demanding requests.
 
 More information [here](https://fastapi.tiangolo.com/async/#in-a-hurry)
+
+### Startup functions
+Be sure to wrap your startup functions with a `@app.on_event("startup")` decorator

--- a/README.md
+++ b/README.md
@@ -270,13 +270,31 @@ def sparql_escape(obj)
 >
 > The `sparql_escape_uri`-function can be used for escaping URI's.
 
-#### `wait_for_triplestore`
+### Waiting for system ready
+
+Full functionality for waiting for the system to be stable and ready (database up, triplestore ready, migrations ran, ...) is being planned as a cross-template feature, but not ready at the moment. While waiting for this functionality to arrive in the template, one can add a custom function that does a much more simplistic check like this
 
 ```python
-def wait_for_triplestore()
+def wait_for_triplestore():
+    triplestore_live = False
+    log("Waiting for triplestore...")
+    while not triplestore_live:
+        try:
+            result = query(
+                """
+                SELECT ?s WHERE {
+                ?s ?p ?o.
+                } LIMIT 1""",
+            )
+            if result["results"]["bindings"][0]["s"]["value"]:
+                triplestore_live = True
+            else:
+                raise Exception("triplestore not ready yet...")
+        except Exception as _e:
+            log("Triplestore not live yet, retrying...")
+            time.sleep(1)
+    log("Triplestore ready!")
 ```
-
-> Wait until the triplestore is running. Performs a sudo select query with limit 1 until it gets a proper result from the triplestore
 
 ### Writing SPARQL Queries
 

--- a/README.md
+++ b/README.md
@@ -134,27 +134,27 @@ def validate_resource_type(expected_type, data)
 #### `query`
 
 ```python
-def query(the_query, sudo = False )
+def query(the_query, sudo = False, scope = None )
 ```
 
 > Execute the given SPARQL query (select/ask/construct) on the triplestore and returns the results in the given return Format (JSON by default).
 >
 > Advanced options:
-> - sudo: perform a sudo query, ignoring the groups of the originating
-
+> - sudo: perform a sudo query, ignoring the groups of the originating, note that you are only allowed to make sudo queries if the environment variable `ALLOW_MU_AUTH_SUDO` is set to `true` (or `True` or `yes`)
+> - scope: a scope string to use when executing this query. If left as None, the default scope of `DEFAULT_MU_AUTH_SCOPE` is used if any. Otherwise, no scope is used in the query
 <a id="helpers.update"></a>
 
 #### `update`
 
 ```python
-def update(the_query, sudo = False)
+def update(the_query, sudo = False, scope = None)
 ```
 
 > Execute the given update SPARQL query on the triplestore. If the given query is not an update query, nothing happens.
 >
 > Advanced options:
-> - sudo: perform a sudo query, ignoring the groups of the originating request
-
+> - sudo: perform a sudo query, ignoring the groups of the originating request, note that you are only allowed to make sudo queries if the environment variable `ALLOW_MU_AUTH_SUDO` is set to `true` (or `True` or `yes`)
+> - scope: a scope string to use when executing this query. If left as None, the default scope of `DEFAULT_MU_AUTH_SCOPE` is used if any. Otherwise, no scope is used in the query
 <a id="helpers.update_modified"></a>
 
 #### `update_modified`

--- a/README.md
+++ b/README.md
@@ -134,13 +134,12 @@ def validate_resource_type(expected_type, data)
 #### `query`
 
 ```python
-def query(the_query, request = None, thread_safe = False, sudo = False )
+def query(the_query, thread_safe = False, sudo = False )
 ```
 
 > Execute the given SPARQL query (select/ask/construct) on the triplestore and returns the results in the given return Format (JSON by default).
 >
 > Advanced options:
-> - request: pass in the original request to add in MU-SESSION-ID, MU-CALL-ID, MU-AUTH-ALLOWED-GROUPS, MU-AUTH-USED-GROUPS headers to the sparql request
 > - thread_safe: you may configure fastapi to use multiple worker threads and still use sudo or request to modify the sparql request's http headers. If so, use thread_safe to create a new sparql client every time to avoid contamination of the sparqlQuery object by other threads. Slight performance loss, but hey, you got threads!
 > - sudo: perform a sudo query, ignoring the groups of the originating
 
@@ -149,13 +148,12 @@ def query(the_query, request = None, thread_safe = False, sudo = False )
 #### `update`
 
 ```python
-def update(the_query)
+def update(the_query, thread_safe = False, sudo = False)
 ```
 
 > Execute the given update SPARQL query on the triplestore. If the given query is not an update query, nothing happens.
 >
 > Advanced options:
-> - request: pass in the original request to add in MU-SESSION-ID, MU-CALL-ID, MU-AUTH-ALLOWED-GROUPS, MU-AUTH-USED-GROUPS headers to the sparql request
 > - thread_safe: you may configure fastapi to use multiple worker threads and still use sudo or request to modify the sparql request's http headers. If so, use thread_safe to create a new sparql client every time to avoid contamination of the sparqlQuery object by other threads. Slight performance loss, but hey, you got threads!
 > - sudo: perform a sudo query, ignoring the groups of the originating request
 

--- a/README.md
+++ b/README.md
@@ -134,13 +134,12 @@ def validate_resource_type(expected_type, data)
 #### `query`
 
 ```python
-def query(the_query, thread_safe = False, sudo = False )
+def query(the_query, sudo = False )
 ```
 
 > Execute the given SPARQL query (select/ask/construct) on the triplestore and returns the results in the given return Format (JSON by default).
 >
 > Advanced options:
-> - thread_safe: you may configure fastapi to use multiple worker threads and still use sudo or request to modify the sparql request's http headers. If so, use thread_safe to create a new sparql client every time to avoid contamination of the sparqlQuery object by other threads. Slight performance loss, but hey, you got threads!
 > - sudo: perform a sudo query, ignoring the groups of the originating
 
 <a id="helpers.update"></a>
@@ -148,13 +147,12 @@ def query(the_query, thread_safe = False, sudo = False )
 #### `update`
 
 ```python
-def update(the_query, thread_safe = False, sudo = False)
+def update(the_query, sudo = False)
 ```
 
 > Execute the given update SPARQL query on the triplestore. If the given query is not an update query, nothing happens.
 >
 > Advanced options:
-> - thread_safe: you may configure fastapi to use multiple worker threads and still use sudo or request to modify the sparql request's http headers. If so, use thread_safe to create a new sparql client every time to avoid contamination of the sparqlQuery object by other threads. Slight performance loss, but hey, you got threads!
 > - sudo: perform a sudo query, ignoring the groups of the originating request
 
 <a id="helpers.update_modified"></a>

--- a/helpers.py
+++ b/helpers.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import os
 import sys
+import time
 from fastapi import Request
 from rdflib.namespace import DC
 from escape_helpers import sparql_escape
@@ -183,6 +184,27 @@ def update(the_query: str, request: Request | None = None, thread_safe: bool = F
         except Exception as e:
             log("Failed Query: \n" + the_query)
             raise e
+
+def wait_for_triplestore():
+    triplestore_live = False
+    log("Waiting for triplestore...")
+    while not triplestore_live:
+        try:
+            result = query(
+                """
+                SELECT ?s WHERE {
+                ?s ?p ?o.
+                } LIMIT 1""",
+                sudo=True
+            )
+            if result["results"]["bindings"][0]["s"]["value"]:
+                triplestore_live = True
+            else:
+                raise Exception("triplestore not ready yet...")
+        except Exception as _e:
+            log("Triplestore not live yet, retrying...")
+            time.sleep(1)
+    log("Triplestore ready!")
 
 
 def update_modified(subject, modified=datetime.datetime.now()):

--- a/helpers.py
+++ b/helpers.py
@@ -26,6 +26,8 @@ Available functions:
 """
 
 MU_APPLICATION_GRAPH = os.environ.get('MU_APPLICATION_GRAPH')
+ALLOW_MU_AUTH_SUDO = os.environ.get("ALLOW_MU_AUTH_SUDO") in ['true', 'True', 'yes']
+DEFAULT_MU_AUTH_SCOPE = os.environ.get("DEFAULT_MU_AUTH_SCOPE")
 
 # TODO: Figure out how logging works when production uses multiple workers
 log_levels = {
@@ -131,7 +133,7 @@ MU_HEADERS = [
     "MU-AUTH-USED-GROUPS"
 ]
 
-def set_sparql_interface_headers(sparql_interface, sudo):
+def set_sparql_interface_headers(sparql_interface, sudo=False, scope=None):
     for header in MU_HEADERS:
         if context.exists() and header in context["headers"]:
             sparql_interface.customHttpHeaders[header] = context["headers"][header]
@@ -139,18 +141,28 @@ def set_sparql_interface_headers(sparql_interface, sudo):
             if header in sparql_interface.customHttpHeaders:
                 del sparql_interface.customHttpHeaders[header]
     if sudo:
-        sparql_interface.customHttpHeaders["mu-auth-sudo"] = "true"
+        if ALLOW_MU_AUTH_SUDO:
+            sparql_interface.customHttpHeaders["mu-auth-sudo"] = "true"
+        else:
+            from web import BaseHTTPException
+            raise BaseHTTPException(403, "tried to execute sudo query without explicit permission on container level")
     elif "mu-auth-sudo" in sparql_interface.customHttpHeaders:
         del sparql_interface.customHttpHeaders["mu-auth-sudo"]
 
+    if scope:
+        sparql_interface.customHttpHeaders["mu-auth-scope"] = scope
+    elif DEFAULT_MU_AUTH_SCOPE:
+        sparql_interface.customHttpHeaders["mu-auth-scope"] = DEFAULT_MU_AUTH_SCOPE
+    elif "mu-auth_scope" in sparql_interface.customHttpHeaders:
+        del sparql_interface.customHttpHeaders["mu-auth-scope"]
 
 
-def query(the_query: str, sudo: bool = False):
+def query(the_query: str, sudo: bool = False, scope: str | None = None):
     """Execute the given SPARQL query (select/ask/construct) on the triplestore and returns the results in the given return Format (JSON by default)."""
     # we're editing properties of sparql_interface, if this is done by multiple worker threads, the behavior is undefined, better create a new instance
     sparql_interface = build_sparql_query()
 
-    set_sparql_interface_headers(sparql_interface, sudo)
+    set_sparql_interface_headers(sparql_interface, sudo=sudo, scope=scope)
 
     sparql_interface.setQuery(the_query)
     if LOG_SPARQL_QUERIES:
@@ -162,12 +174,12 @@ def query(the_query: str, sudo: bool = False):
         raise e
 
 
-def update(the_query: str, sudo: bool = False):
+def update(the_query: str, sudo: bool = False, scope: str | None = None):
     """Execute the given update SPARQL query on the triplestore. If the given query is not an update query, nothing happens."""
     # we're editing properties of sparql_interface, if this is done by multiple worker threads, the behavior is undefined, better create a new instance
     sparql_interface = build_sparql_update()
 
-    set_sparql_interface_headers(sparql_interface, sudo)
+    set_sparql_interface_headers(sparql_interface, sudo=sudo, scope=scope)
 
     sparql_interface.setQuery(the_query)
     if sparql_interface.isSparqlUpdateRequest():
@@ -189,7 +201,6 @@ def wait_for_triplestore():
                 SELECT ?s WHERE {
                 ?s ?p ?o.
                 } LIMIT 1""",
-                sudo=True
             )
             if result["results"]["bindings"][0]["s"]["value"]:
                 triplestore_live = True

--- a/helpers.py
+++ b/helpers.py
@@ -157,7 +157,7 @@ def set_sparql_interface_headers(sparql_interface, sudo=False, scope=None):
         del sparql_interface.customHttpHeaders["mu-auth-scope"]
 
 
-def query(the_query: str, sudo: bool = False, scope: str | None = None):
+def query(the_query: str, *, sudo: bool = False, scope: str | None = None):
     """Execute the given SPARQL query (select/ask/construct) on the triplestore and returns the results in the given return Format (JSON by default)."""
     # we're editing properties of sparql_interface, if this is done by multiple worker threads, the behavior is undefined, better create a new instance
     sparql_interface = build_sparql_query()
@@ -174,7 +174,7 @@ def query(the_query: str, sudo: bool = False, scope: str | None = None):
         raise e
 
 
-def update(the_query: str, sudo: bool = False, scope: str | None = None):
+def update(the_query: str, *, sudo: bool = False, scope: str | None = None):
     """Execute the given update SPARQL query on the triplestore. If the given query is not an update query, nothing happens."""
     # we're editing properties of sparql_interface, if this is done by multiple worker threads, the behavior is undefined, better create a new instance
     sparql_interface = build_sparql_update()

--- a/helpers.py
+++ b/helpers.py
@@ -61,11 +61,11 @@ def generate_uuid():
 def log(msg, *args, **kwargs):
     """
     Write a log message to the log file.
-    
+
     Works exactly the same as the logging.info (https://docs.python.org/3/library/logging.html#logging.info) method from pythons' logging module.
-    Logs are written to the /logs directory in the docker container.  
-    
-    Note that the `helpers` module also exposes `logger`, which is the logger instance (https://docs.python.org/3/library/logging.html#logger-objects) 
+    Logs are written to the /logs directory in the docker container.
+
+    Note that the `helpers` module also exposes `logger`, which is the logger instance (https://docs.python.org/3/library/logging.html#logger-objects)
     used by the template. The methods provided by this instance can be used for more fine-grained logging.
     """
     return logger.info(msg, *args, **kwargs)
@@ -105,14 +105,23 @@ def validate_resource_type(expected_type, data):
         return error("Incorrect type. Type must be " + str(expected_type) +
                      ", instead of " + str(data['type']) + ".", 409)
 
+def build_sparql_query():
+    sparql_query = SPARQLWrapper(os.environ.get('MU_SPARQL_ENDPOINT'), returnFormat=JSON)
+    if os.environ.get('MU_SPARQL_TIMEOUT'):
+        timeout = int(os.environ.get('MU_SPARQL_TIMEOUT'))
+        sparql_query.setTimeout(timeout)
+    return sparql_query
 
-sparqlQuery = SPARQLWrapper(os.environ.get('MU_SPARQL_ENDPOINT'), returnFormat=JSON)
-sparqlUpdate = SPARQLWrapper(os.environ.get('MU_SPARQL_UPDATEPOINT'), returnFormat=JSON)
-sparqlUpdate.method = 'POST'
-if os.environ.get('MU_SPARQL_TIMEOUT'):
-    timeout = int(os.environ.get('MU_SPARQL_TIMEOUT'))
-    sparqlQuery.setTimeout(timeout)
-    sparqlUpdate.setTimeout(timeout)
+def build_sparql_update():
+    sparql_update = SPARQLWrapper(os.environ.get('MU_SPARQL_UPDATEPOINT'), returnFormat=JSON)
+    sparql_update.method = 'POST'
+    if os.environ.get('MU_SPARQL_TIMEOUT'):
+        timeout = int(os.environ.get('MU_SPARQL_TIMEOUT'))
+        sparql_update.setTimeout(timeout)
+    return sparql_update
+
+sparqlQuery = build_sparql_query()
+sparqlUpdate = build_sparql_update()
 
 MU_HEADERS = [
     "MU-SESSION-ID",
@@ -121,38 +130,56 @@ MU_HEADERS = [
     "MU-AUTH-USED-GROUPS"
 ]
 
-def query(the_query: str, request: Request | None = None):
-    """Execute the given SPARQL query (select/ask/construct) on the triplestore and returns the results in the given return Format (JSON by default)."""
+def set_sparql_interface_headers(sparql_interface, request, sudo):
     for header in MU_HEADERS:
         if request is not None and header in request.headers:
-            sparqlQuery.customHttpHeaders[header] = request.headers[header]
+            sparql_interface.customHttpHeaders[header] = request.headers[header]
         else: # Make sure headers used for a previous query are cleared
-            if header in sparqlQuery.customHttpHeaders:
-                del sparqlQuery.customHttpHeaders[header]
-    sparqlQuery.setQuery(the_query)
+            if header in sparql_interface.customHttpHeaders:
+                del sparql_interface.customHttpHeaders[header]
+    if sudo:
+        sparql_interface.customHttpHeaders["mu-auth-sudo"] = "true"
+    else:
+        del sparql_interface.customHttpHeaders["mu-auth-sudo"]
+
+
+
+def query(the_query: str, request: Request | None = None, thread_safe: bool = False, sudo: bool = False):
+    """Execute the given SPARQL query (select/ask/construct) on the triplestore and returns the results in the given return Format (JSON by default)."""
+    sparql_interface = sparqlQuery
+
+    if thread_safe:
+        # we're editing properties of sparql_interface, if this is done by multiple worker threads, the behavior is undefined, better create a new instance
+        sparql_interface = build_sparql_query()
+
+    set_sparql_interface_headers(sparql_interface, request, sudo)
+
+    sparql_interface.setQuery(the_query)
     if LOG_SPARQL_QUERIES:
         log("Execute query: \n" + the_query)
     try:
-        return sparqlQuery.query().convert()
+        return sparql_interface.query().convert()
     except Exception as e:
         log("Failed Query: \n" + the_query)
         raise e
 
 
-def update(the_query: str, request: Request | None = None):
+def update(the_query: str, request: Request | None = None, thread_safe: bool = False, sudo: bool = False):
     """Execute the given update SPARQL query on the triplestore. If the given query is not an update query, nothing happens."""
-    for header in MU_HEADERS:
-        if request is not None and header in request.headers:
-            sparqlUpdate.customHttpHeaders[header] = request.headers[header]
-        else: # Make sure headers used for a previous query are cleared
-            if header in sparqlUpdate.customHttpHeaders:
-                del sparqlUpdate.customHttpHeaders[header]
-    sparqlUpdate.setQuery(the_query)
-    if sparqlUpdate.isSparqlUpdateRequest():
+    sparql_interface = sparqlUpdate
+
+    if thread_safe:
+        # we're editing properties of sparql_interface, if this is done by multiple worker threads, the behavior is undefined, better create a new instance
+        sparql_interface = build_sparql_update()
+
+    set_sparql_interface_headers(sparql_interface, request, sudo)
+
+    sparql_interface.setQuery(the_query)
+    if sparql_interface.isSparqlUpdateRequest():
         if LOG_SPARQL_UPDATES:
             log("Execute query: \n" + the_query)
         try:
-            sparqlUpdate.query()
+            sparql_interface.query()
         except Exception as e:
             log("Failed Query: \n" + the_query)
             raise e

--- a/helpers.py
+++ b/helpers.py
@@ -191,27 +191,6 @@ def update(the_query: str, *, sudo: bool = False, scope: str | None = None):
             log("Failed Query: \n" + the_query)
             raise e
 
-def wait_for_triplestore():
-    triplestore_live = False
-    log("Waiting for triplestore...")
-    while not triplestore_live:
-        try:
-            result = query(
-                """
-                SELECT ?s WHERE {
-                ?s ?p ?o.
-                } LIMIT 1""",
-            )
-            if result["results"]["bindings"][0]["s"]["value"]:
-                triplestore_live = True
-            else:
-                raise Exception("triplestore not ready yet...")
-        except Exception as _e:
-            log("Triplestore not live yet, retrying...")
-            time.sleep(1)
-    log("Triplestore ready!")
-
-
 def update_modified(subject, modified=datetime.datetime.now()):
     """(DEPRECATED) Executes a SPARQL query to update the modification date of the given subject URI (string).
      The default date is now."""

--- a/helpers.py
+++ b/helpers.py
@@ -4,11 +4,11 @@ import logging
 import os
 import sys
 import time
-from fastapi import Request
 from rdflib.namespace import DC
 from escape_helpers import sparql_escape
 from SPARQLWrapper import SPARQLWrapper, JSON
 from deprecated import deprecated
+from starlette_context import context
 
 """
 The template provides the user with several helper methods. They aim to give you a step ahead for:
@@ -131,21 +131,21 @@ MU_HEADERS = [
     "MU-AUTH-USED-GROUPS"
 ]
 
-def set_sparql_interface_headers(sparql_interface, request, sudo):
+def set_sparql_interface_headers(sparql_interface, sudo):
     for header in MU_HEADERS:
-        if request is not None and header in request.headers:
-            sparql_interface.customHttpHeaders[header] = request.headers[header]
+        if context.exists() and header in context["headers"]:
+            sparql_interface.customHttpHeaders[header] = context["headers"][header]
         else: # Make sure headers used for a previous query are cleared
             if header in sparql_interface.customHttpHeaders:
                 del sparql_interface.customHttpHeaders[header]
     if sudo:
         sparql_interface.customHttpHeaders["mu-auth-sudo"] = "true"
-    else:
+    elif "mu-auth-sudo" in sparql_interface.customHttpHeaders:
         del sparql_interface.customHttpHeaders["mu-auth-sudo"]
 
 
 
-def query(the_query: str, request: Request | None = None, thread_safe: bool = False, sudo: bool = False):
+def query(the_query: str, thread_safe: bool = False, sudo: bool = False):
     """Execute the given SPARQL query (select/ask/construct) on the triplestore and returns the results in the given return Format (JSON by default)."""
     sparql_interface = sparqlQuery
 
@@ -153,7 +153,7 @@ def query(the_query: str, request: Request | None = None, thread_safe: bool = Fa
         # we're editing properties of sparql_interface, if this is done by multiple worker threads, the behavior is undefined, better create a new instance
         sparql_interface = build_sparql_query()
 
-    set_sparql_interface_headers(sparql_interface, request, sudo)
+    set_sparql_interface_headers(sparql_interface, sudo)
 
     sparql_interface.setQuery(the_query)
     if LOG_SPARQL_QUERIES:
@@ -165,7 +165,7 @@ def query(the_query: str, request: Request | None = None, thread_safe: bool = Fa
         raise e
 
 
-def update(the_query: str, request: Request | None = None, thread_safe: bool = False, sudo: bool = False):
+def update(the_query: str, thread_safe: bool = False, sudo: bool = False):
     """Execute the given update SPARQL query on the triplestore. If the given query is not an update query, nothing happens."""
     sparql_interface = sparqlUpdate
 
@@ -173,7 +173,7 @@ def update(the_query: str, request: Request | None = None, thread_safe: bool = F
         # we're editing properties of sparql_interface, if this is done by multiple worker threads, the behavior is undefined, better create a new instance
         sparql_interface = build_sparql_update()
 
-    set_sparql_interface_headers(sparql_interface, request, sudo)
+    set_sparql_interface_headers(sparql_interface, sudo)
 
     sparql_interface.setQuery(the_query)
     if sparql_interface.isSparqlUpdateRequest():

--- a/helpers.py
+++ b/helpers.py
@@ -145,13 +145,10 @@ def set_sparql_interface_headers(sparql_interface, sudo):
 
 
 
-def query(the_query: str, thread_safe: bool = False, sudo: bool = False):
+def query(the_query: str, sudo: bool = False):
     """Execute the given SPARQL query (select/ask/construct) on the triplestore and returns the results in the given return Format (JSON by default)."""
-    sparql_interface = sparqlQuery
-
-    if thread_safe:
-        # we're editing properties of sparql_interface, if this is done by multiple worker threads, the behavior is undefined, better create a new instance
-        sparql_interface = build_sparql_query()
+    # we're editing properties of sparql_interface, if this is done by multiple worker threads, the behavior is undefined, better create a new instance
+    sparql_interface = build_sparql_query()
 
     set_sparql_interface_headers(sparql_interface, sudo)
 
@@ -165,13 +162,10 @@ def query(the_query: str, thread_safe: bool = False, sudo: bool = False):
         raise e
 
 
-def update(the_query: str, thread_safe: bool = False, sudo: bool = False):
+def update(the_query: str, sudo: bool = False):
     """Execute the given update SPARQL query on the triplestore. If the given query is not an update query, nothing happens."""
-    sparql_interface = sparqlUpdate
-
-    if thread_safe:
-        # we're editing properties of sparql_interface, if this is done by multiple worker threads, the behavior is undefined, better create a new instance
-        sparql_interface = build_sparql_update()
+    # we're editing properties of sparql_interface, if this is done by multiple worker threads, the behavior is undefined, better create a new instance
+    sparql_interface = build_sparql_update()
 
     set_sparql_interface_headers(sparql_interface, sudo)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,5 @@ dependencies = [
     "rdflib>=7.2.1",
     "sparqlwrapper>=2.0.0",
     "uvicorn>=0.37.0",
+    "starlette-context>=0.4.0",
 ]

--- a/web.py
+++ b/web.py
@@ -8,12 +8,26 @@ from fastapi.responses import Response
 from jsonapi_pydantic.v1_0 import Error, TopLevel, Meta, Source, ErrorLinks
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from rdflib.namespace import Namespace
+from starlette.middleware import Middleware
+from starlette_context.middleware import RawContextMiddleware
+from fastapi import Request
+from helpers import MU_HEADERS
 
 import helpers
 from escape_helpers import sparql_escape
 
+class CustomContextMiddleware(RawContextMiddleware):
+    async def set_context(self, request: Request) -> dict:
+        context = await super().set_context(request)
+        headers = {}
+        context["headers"] = headers
+        for header in MU_HEADERS:
+            if header in request.headers:
+                headers[header] = request.headers[header]
+        return context
+
 # WSGI variable name used by the server
-app = FastAPI()
+app = FastAPI(middleware=[Middleware(CustomContextMiddleware)])
 
 
 class BaseHTTPException(StarletteHTTPException):


### PR DESCRIPTION
- automatically pass along the mu headers to the sparql helpers
- make sparql helpers thread safe
- add sudo query support
- allow waiting for triplestore
- extend readme with the features above and a warning about startup functions